### PR TITLE
Remove foreach loop in demo.php

### DIFF
--- a/demo.php
+++ b/demo.php
@@ -1,12 +1,6 @@
 <?php
 
-$raw_files = glob('*.*');
-$files = array();
-
-foreach( $raw_files as $r ){
-  if( preg_match( '/\.(?:png|jpg|jpeg)$/' , $r ) )
-    $files[] = $r;
-}
+$files = glob('*.{png,jpg,jpeg}', GLOB_BRACE);
 
 ?><!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
The [`glob()`](http://php.net/glob) function can expand arguments within curly braces. This allows you write the following.

``` php
$files = glob('*.{png,jpg,jpeg}', GLOB_BRACE);
```

The above code will find all files in the current directory that have an image extension without using a `foreach` loop.
